### PR TITLE
test: dont run tsc when install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tsc": "tsc -p tsconfig.json",
     "ci": "npm run lint && npm run cov && npm run tsc",
     "autod": "autod",
-    "prepublish": "npm run tsc",
+    "prepublishOnly": "npm run tsc",
     "lint": "tslint --project . -c tslint.json"
   },
   "main": "index.js",


### PR DESCRIPTION
prepublish will be run before npm install