### PR TITLE
Default value for headers

### DIFF
--- a/lib/http/http_error.ts
+++ b/lib/http/http_error.ts
@@ -5,7 +5,7 @@ import HttpHeader from './http_header';
 class HttpError extends EggError<HttpErrorOptions> {
 
   public status: number;
-  public headers?: HttpHeader = [];
+  public headers?: HttpHeader = {};
   protected options: HttpErrorOptions;
 
   constructor(options?: HttpErrorOptions) {

--- a/lib/http/http_error.ts
+++ b/lib/http/http_error.ts
@@ -5,7 +5,7 @@ import HttpHeader from './http_header';
 class HttpError extends EggError<HttpErrorOptions> {
 
   public status: number;
-  public headers?: HttpHeader;
+  public headers?: HttpHeader = [];
   protected options: HttpErrorOptions;
 
   constructor(options?: HttpErrorOptions) {

--- a/lib/http/http_header.ts
+++ b/lib/http/http_header.ts
@@ -1,3 +1,3 @@
 export default class HttpHeader {
-  [key: string]: string;
+  [key: string]: string | number;
 }

--- a/test/http/429.test.ts
+++ b/test/http/429.test.ts
@@ -9,4 +9,11 @@ describe('test/http/429.test.ts', () => {
     assert(err.name === 'TooManyRequestsError');
     assert(err.status === 429);
   });
+  
+  it('should not throw an error', function() {
+    (function() {
+      const error = new TooManyRequestsError();
+      error.headers['Retry-After'] = 120;
+    }).should.not.throw();
+  });
 });

--- a/test/http/429.test.ts
+++ b/test/http/429.test.ts
@@ -11,7 +11,7 @@ describe('test/http/429.test.ts', () => {
   });
   
   it('should not throw an error', function() {
-    (function() {
+    (()=>{
       const error = new TooManyRequestsError();
       error.headers['Retry-After'] = 120;
     }).should.not.throw();

--- a/test/http/429.test.ts
+++ b/test/http/429.test.ts
@@ -9,7 +9,6 @@ describe('test/http/429.test.ts', () => {
     assert(err.name === 'TooManyRequestsError');
     assert(err.status === 429);
   });
-  
   it('should not throw an error', () => {
     (() => {
       const error = new TooManyRequestsError();

--- a/test/http/429.test.ts
+++ b/test/http/429.test.ts
@@ -10,8 +10,8 @@ describe('test/http/429.test.ts', () => {
     assert(err.status === 429);
   });
   
-  it('should not throw an error', function() {
-    (()=>{
+  it('should not throw an error', () => {
+    (() => {
       const error = new TooManyRequestsError();
       error.headers['Retry-After'] = 120;
     }).should.not.throw();


### PR DESCRIPTION
As `headers` 's default value is undefined , We cannot do the following

```js
const error = new TooManyRequestsError();
error.headers['Retry-After'] = 120;
```

We have `Cannot set property 'Retry-After' of undefined` error