### PR TITLE
优化 Base.from 方法声明及调用

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: node_js
 node_js:
   - '8'
   - '10'
+before_install:
+  - npm i npminstall -g
 install:
-  - npm i npminstall && npminstall
+  - npminstall
 script:
   - npm run ci
 after_script:

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -11,15 +11,18 @@ class BaseError<T extends ErrorOptions> extends Error {
     return (err as any)[TYPE] || ErrorType.BUILTIN;
   }
 
-  public static from(err: Error): BaseError<ErrorOptions> {
+  public static from<
+    S extends new (...args: any) => InstanceType<typeof BaseError>,
+    P extends ConstructorParameters<S>
+  >(this: S, err: Error, ...args: P | undefined[]): InstanceType<S> {
     const ErrorClass = this;
-    const newErr = new ErrorClass<ErrorOptions>();
+    const newErr = new ErrorClass(...args as any[]);
     newErr.message = err.message;
     newErr.stack = err.stack;
     for (const key of Object.keys(err)) {
       newErr[key] = err[key];
     }
-    return newErr;
+    return newErr as InstanceType<S>;
   }
 
   public code: string;

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -126,6 +126,48 @@ describe('test/error.test.ts', () => {
       assert(err2.stack === err.stack);
     });
 
+    it('should create custom Error whit constructor params', () => {
+      interface CustomErrorOptions extends ErrorOptions {
+        add: string;
+      }
+
+      class CustomError extends EggBaseError<CustomErrorOptions> {
+        custom: boolean;
+        constructor(options: CustomErrorOptions, custom: boolean) {
+          super(options);
+          this.custom = custom;
+        }
+      }
+      const err = new Error('error message');
+      const err2 = CustomError.from(err, { code: 'CustomCode', message: 'custom message', add: '' }, true);
+      assert(err2.code === 'CustomCode');
+      assert(err2.message === 'error message');
+      assert(err2.name === 'CustomError');
+      assert(err2.stack === err.stack);
+      assert(err2.custom === true);
+    });
+
+    it('should create custom Error not whit constructor params', () => {
+      interface CustomErrorOptions extends ErrorOptions {
+        add: string;
+      }
+
+      class CustomError extends EggBaseError<CustomErrorOptions> {
+        custom: boolean;
+        constructor(options: CustomErrorOptions, custom: boolean) {
+          super(options);
+          this.custom = custom;
+        }
+      }
+      const err = new Error('error message');
+      const err2 = CustomError.from(err);
+      assert(err2.code === '');
+      assert(err2.message === 'error message');
+      assert(err2.name === 'CustomError');
+      assert(err2.stack === err.stack);
+      assert(err2.custom === undefined);
+    });
+
     it('should create http Error', () => {
       const err = new Error('error message');
       const err2 = InternalServerError.from(err);
@@ -138,7 +180,7 @@ describe('test/error.test.ts', () => {
 
   describe('extendable', () => {
     it('custom error', () => {
-      class CustomError extends EggBaseError<ErrorOptions> {}
+      class CustomError extends EggBaseError<ErrorOptions> { }
       const err = new CustomError({
         code: 'CODE',
         message: 'error',


### PR DESCRIPTION
1. 当前子类调用继承的 from 方法，可以正确显示返回的实例类型。
2. 通过 from 方法，可以和 new 一个实例一样，添加扩展信息，而且参数自动映射。

![image](https://user-images.githubusercontent.com/12657964/69147897-0637f680-0b0e-11ea-886f-282c62cac77f.png)
